### PR TITLE
Pagination Support

### DIFF
--- a/dnsclient/exceptions.py
+++ b/dnsclient/exceptions.py
@@ -83,6 +83,8 @@ class ClientException(Exception):
 
     def __str__(self):
         formatted_string = "%s (HTTP %s)" % (self.message, self.code)
+        if self.details:
+            formatted_string += ' - %s' % self.details
         if self.request_id:
             formatted_string += " (Request-ID: %s)" % self.request_id
 
@@ -163,7 +165,9 @@ def from_response(response, body):
         message = "n/a"
         details = "n/a"
         if hasattr(body, 'keys'):
-            error = body[body.keys()[0]]
+            error = body
+            if 'message' not in body.keys() or 'details' not in body.keys():
+                error = body[body.keys()[0]]
             message = error.get('message', None)
             details = error.get('details', None)
         return cls(code=response.status, message=message, details=details,


### PR DESCRIPTION
Rackspace paginates any list-esque calls to their API. Therefore, such calls from `rackdns` will return only the first 100 results. If you have more than 100 records (say, because you have lots of subdomains on a given domain), it is impossible to see the ones beyond the first 100 with this tool.

This pull request adds support for pagination, automatically detecting if a `totalEntries` key is sent down that is greater than 100 and making additional requests using the `offset` GET key until all records have been retrieved.

It also fixes a slight bug with error handling.
