### PR TITLE
Fix novaclient incompat in pip-requires

### DIFF
--- a/tools/pip-requires
+++ b/tools/pip-requires
@@ -4,3 +4,6 @@ iso8601>=0.1.4
 prettytable>=0.6,<0.7
 simplejson
 rackspace-auth-openstack
+# Novaclient  4.0.0 and later is incompat with prettytable requirements
+python-novaclient<4.0.0
+


### PR DESCRIPTION
Novaclient>=4.0.0 is incompat with the prettytable requirements cap novaclient at 4.0.0

related to #3 
